### PR TITLE
Numark Platinum FX - Fix for pad mode buttons staying blinking in error sometimes

### DIFF
--- a/res/controllers/Numark-Mixtrack-Platinum-FX-scripts.js
+++ b/res/controllers/Numark-Mixtrack-Platinum-FX-scripts.js
@@ -111,7 +111,7 @@ MixtrackPlatinumFX.BlinkStart = function(callback, slow) {
             // empty slot
             MixtrackPlatinumFX.CallBacks[i]=callback;
             MixtrackPlatinumFX.CallSpeed[i]=slow;
-            return i+1;
+            return Number(i)+1;
         }
     }
     const idx = MixtrackPlatinumFX.CallBacks.push(callback);


### PR DESCRIPTION
Numark Mixtrack Platinum FX mapping - Pad Mode Button Problem

Problem description:

The pad mode buttons sometimes remain blinking in error.

Steps to reproduce:

Boot Mixxx with a configured & working Mixtrack plugged in.

- On deck 1 press shift and the Hot Cue button
- On deck 2 press shift and the Hot Cue button
- On deck 2 press shift and the Auto Loop button
- On deck 2 press shift and the Hot Cue button

At this point deck 2's Auto Loop pad mode button will still be blinking, even though the selected mode is Hot Cues, second bank.

With some tinkering it is possible to have all 8 pad mode buttons blinking simultaneously!

Reason for problem:

At line 108 in Numark-Mixtrack-Platinum-FX-scripts.js

```
MixtrackPlatinumFX.BlinkStart = function(callback, slow) {
    for (const i in MixtrackPlatinumFX.CallBacks) {
        if (!MixtrackPlatinumFX.CallBacks[i]) {
            // empty slot
            MixtrackPlatinumFX.CallBacks[i]=callback;
            MixtrackPlatinumFX.CallSpeed[i]=slow;
****            return i+1;
        }
    }
```

The highlighted line expects to return i + 1. However, i is a string at this point, so the returned value is the string concatenation of i and "1", e.g. if i=1, the return value is "11". Other code then fails to delete blinking buttons because in this example case, "11" is not a valid array slot.