### PR TITLE
Platinum FX: Fix broken pad mode long press functionality for Mixxx 2.4+

### DIFF
--- a/res/controllers/Numark-Mixtrack-Platinum-FX-scripts.js
+++ b/res/controllers/Numark-Mixtrack-Platinum-FX-scripts.js
@@ -1026,12 +1026,14 @@ MixtrackPlatinumFX.PadSection = function(deckNumber) {
                     this.longPressMode=MixtrackPlatinumFX.PadModeControls.FADERCUTS3;
                 }
                 this.longPressHeld = true;
+
+                const mixtrackObject = this; // Can't use 'this' in function below
                 this.longPressTimer = engine.beginTimer(components.Button.prototype.longPressTimeout*2, function() {
-                    if (this.longPressHeld) {
-                        this.setMode(channel, this.longPressMode);
+                    if (mixtrackObject.longPressHeld) {
+                        mixtrackObject.setMode(channel, mixtrackObject.longPressMode);
                     }
-                    this.longPressTimer = 0;
-                    this.longPressHeld = false;
+                    mixtrackObject.longPressTimer = 0;
+                    mixtrackObject.longPressHeld = false;
                 }, true);
             }
         }

--- a/res/controllers/Numark-Mixtrack-Platinum-FX-scripts.js
+++ b/res/controllers/Numark-Mixtrack-Platinum-FX-scripts.js
@@ -1027,13 +1027,13 @@ MixtrackPlatinumFX.PadSection = function(deckNumber) {
                 }
                 this.longPressHeld = true;
 
-                const mixtrackObject = this; // Can't use 'this' in function below
+                const thirdaryMode = this; // Can't use 'this' in function below
                 this.longPressTimer = engine.beginTimer(components.Button.prototype.longPressTimeout*2, function() {
-                    if (mixtrackObject.longPressHeld) {
-                        mixtrackObject.setMode(channel, mixtrackObject.longPressMode);
+                    if (thirdaryMode.longPressHeld) {
+                        thirdaryMode.setMode(channel, thirdaryMode.longPressMode);
                     }
-                    mixtrackObject.longPressTimer = 0;
-                    mixtrackObject.longPressHeld = false;
+                    thirdaryMode.longPressTimer = 0;
+                    thirdaryMode.longPressHeld = false;
                 }, true);
             }
         }


### PR DESCRIPTION
For the Mixtrack Platinum FX mapping, Mixxx 2.4 brings a Javascript engine update which breaks the long-press functionality of the pad mode select buttons.

Steps to reproduce:

With the pad mode set to hotcues-1, hold the auto-loop pad mode button. Expected result: Mode changes to autoloop-3. Actual result: Mode switches to autoloop-1.

With the pad mode set to hotcues-1, hold the hotcues pad mode button. Expected result: A slight delay, then a mode switch to hotcues-3. Actual result: Immediate switch to hotcues-3. The lack of delay can be verified by tapping and releasing the button instead of holding it - it switches to hotcues-3.

With the pad mode set to hotcues-1, tap and release the hotcues pad mode button (not hold). Expected result: Mode stays at hotcues-1. Actual result: Mode switches to hotcues-3.

Reason for problem:

At about line 1030 in the JS file a function object is created and passed to engine.beginTimer(). In Mixxx 2.3 when the function object is called when the timer expires, 'this' inside the inner function is the same as 'this' in the outer function. In Mixxx 2.4 the inner 'this' is some other object and so the state tracking of longPressTimer and longPressHeld is lost, causing all the problems above.

There is one other instance in the JS file where a function object using 'this' is passed to engine.beginTimer() at about line 1568 which may also be affected.
